### PR TITLE
fix: some servers may not send `isError` if there is not an error

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -338,7 +338,7 @@ pub struct GetPromptResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallToolResult {
     pub content: Vec<MessageContent>,
-    #[serde(rename = "isError")]
+    #[serde(rename = "isError", default)]
     pub is_error: bool,
 }
 


### PR DESCRIPTION
Some mcp servers like https://github.com/modelcontextprotocol/servers/tree/main/src/github will not send is_error key if there is no error, so we may assume that it's false if they don't send it.