### PR TITLE
Relax message read errors

### DIFF
--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -59,7 +59,10 @@ where
                         }
                         let message = match serde_json::from_str::<Message>(trimmed) {
                             Ok(m) => Ok(m),
-                            Err(err) => Err(Error::Serialization(err.to_string())),
+                            Err(err) => {
+                                tracing::warn!(?err, "Message read error");
+                                continue
+                            },
                         };
 
                         let _ = sender_clone.send(message);


### PR DESCRIPTION
Some MCP servers are badly-behaved and send logging/info messages to `stdout`, which is then picked up by the transport and parsed as JSON. e.g the CircleCI MCP sends `Starting CircleCI MCP server in stdio mode...` on startup, which JSON parsing of course fails on.